### PR TITLE
README, describe the `ls` results better after recent change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ camer ls
 -------+--------------------------------
    b   |         npm run build
 ```
-These are the default alias settings.
+Above are some of the default aliases that crammer creates for you.
 
 #### Add
 The `camer add` command adds a new alias. The alias name and the command to be executed are required.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ camer ls
 -------+--------------------------------
    b   |         npm run build
 ```
-Above are some of the default aliases that crammer creates for you.
+Above are some of the default aliases that cramer creates for you.
 
 #### Add
 The `camer add` command adds a new alias. The alias name and the command to be executed are required.

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,4 @@
+//! Types representing all Camer commands.
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
Since the `ls` results no longer represent the _complete list_ of default aliases, I changed the README to reflect this change. 